### PR TITLE
Update attribute mappings to match assertions

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,9 @@ Attribute mapping:
 | Attribute              | Claim                                                 |
 |------------------------|-------------------------------------------------------|
 | `google.subject`       | `assertion.sub`                                       |
-| `attribute.sub`        | `assertion.sub`                                       |
-| `attribute.actor`      | `assertion.actor`                                     |
 | `attribute.repository` | `assertion.project_path` (not `assertion.repository`) |
+| `attribute.user_login` | `assertion.user_login`                                |
+| `attribute.branch`     | `assertion.ref`                                       |
 
 <!-- BEGIN_TF_DOCS -->
 ## Providers

--- a/README.md
+++ b/README.md
@@ -66,9 +66,10 @@ Attribute mapping:
 | Attribute              | Claim                                                 |
 |------------------------|-------------------------------------------------------|
 | `google.subject`       | `assertion.sub`                                       |
+| `attribute.sub`        | `assertion.sub`                                       |
 | `attribute.repository` | `assertion.project_path` (not `assertion.repository`) |
 | `attribute.user_login` | `assertion.user_login`                                |
-| `attribute.branch`     | `assertion.ref`                                       |
+| `attribute.ref`        | `assertion.ref`                                       |
 
 <!-- BEGIN_TF_DOCS -->
 ## Providers

--- a/main.tf
+++ b/main.tf
@@ -70,9 +70,10 @@ resource "google_iam_workload_identity_pool_provider" "provider" {
 
   attribute_mapping = {
     "google.subject"       = "assertion.sub"
+    "attribute.sub"        = "assertion.sub"
     "attribute.user_login" = "assertion.user_login"
     "attribute.repository" = "assertion.project_path"
-    "attribute.branch"     = "assertion.ref"
+    "attribute.ref"        = "assertion.ref"
   }
   oidc {
     allowed_audiences = [var.allowed_audiences]

--- a/main.tf
+++ b/main.tf
@@ -70,9 +70,9 @@ resource "google_iam_workload_identity_pool_provider" "provider" {
 
   attribute_mapping = {
     "google.subject"       = "assertion.sub"
-    "attribute.sub"        = "attribute.sub"
-    "attribute.actor"      = "assertion.actor"
+    "attribute.user_login" = "assertion.user_login"
     "attribute.repository" = "assertion.project_path"
+    "attribute.branch"     = "assertion.ref"
   }
   oidc {
     allowed_audiences = [var.allowed_audiences]


### PR DESCRIPTION
- [x] I read [CONTRIBUTING.md](https://github.com/Cyclenerd/terraform-google-wif-gitlab/blob/master/CONTRIBUTING.md)

## Notes
updated the attribute mappings to better reflect what you can get from gitlab.
- removed `attribute.sub`; it just duplicates `google.subject` if both map to `assertion.sub`
- added user_login and branch. actor doesn't exist, at least not in my pipeline, Hence removed it.

Using these attributes you can then setup `Attribute Conditions`. These are more flexible than putting it all in the principal, e.g. you can have something like  `( attribute.branch == "master" || attribute.branch == "dev" )` as condition then.